### PR TITLE
Temporary cache pytest fixture

### DIFF
--- a/defyes/cache.py
+++ b/defyes/cache.py
@@ -46,25 +46,6 @@ def clear():
         _cache.clear()
 
 
-class TemporaryCache:
-    """Provides a context with a temporary cache.
-
-    Useful for tests. Not thread safe!
-    """
-
-    def __init__(self):
-        self.original_cache = _cache
-
-    def __enter__(self):
-        global _cache
-        _cache = diskcache.Cache()
-        return _cache
-
-    def __exit__(self, *args, **kwargs):
-        global _cache
-        _cache = self.original_cache
-
-
 def disk_cache_middleware(make_request, web3):
     """
     Cache middleware that supports multiple blockchains.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 
+import diskcache
 import pytest
 
 from defyes import add_stderr_logger
@@ -13,3 +14,8 @@ def pytest_addoption(parser):
 def debug_defi_proto(request):
     if request.config.getoption("--debug-defiproto"):
         add_stderr_logger(logging.DEBUG)
+
+
+@pytest.fixture
+def temporary_cache(monkeypatch):
+    monkeypatch.setattr("defyes.cache._cache", diskcache.Cache())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from defyes.cache import TemporaryCache, cache_call, const_call
+from defyes.cache import cache_call, const_call
 
 
 def build_web3_contract_mock():
@@ -19,30 +19,28 @@ def build_web3_contract_mock():
     return web3_contract_function, centinel
 
 
-def test_cache_decorator():
-    with TemporaryCache():
-        centinel = mock.Mock()
+def test_cache_decorator(temporary_cache):
+    centinel = mock.Mock()
 
-        @cache_call(exclude_args=["c", "d"])
-        def f(a, b, c, d=None):
-            centinel()
-            return a + b + c
+    @cache_call(exclude_args=["c", "d"])
+    def f(a, b, c, d=None):
+        centinel()
+        return a + b + c
 
-        assert 3 == f(1, 2, 0)
-        assert centinel.call_count == 1
-        assert 3 == f(1, 2, 0)
-        assert 3 == f(1, 2, 0, "foo")
-        assert 3 == f(1, 2, 3, d="foo")
-        assert centinel.call_count == 1  # only called once
+    assert 3 == f(1, 2, 0)
+    assert centinel.call_count == 1
+    assert 3 == f(1, 2, 0)
+    assert 3 == f(1, 2, 0, "foo")
+    assert 3 == f(1, 2, 3, d="foo")
+    assert centinel.call_count == 1  # only called once
 
 
-def test_const_call():
-    with TemporaryCache():
-        web3_contract_function, centinel = build_web3_contract_mock()
-        const_call(web3_contract_function)
-        assert centinel.call_count == 1
-        const_call(web3_contract_function)
-        assert centinel.call_count == 1  # only called once
+def test_const_call(temporary_cache):
+    web3_contract_function, centinel = build_web3_contract_mock()
+    const_call(web3_contract_function)
+    assert centinel.call_count == 1
+    const_call(web3_contract_function)
+    assert centinel.call_count == 1  # only called once
 
 
 def test_const_cache_disabled():


### PR DESCRIPTION
Replace the `TemporaryCache` class by a monkeypatch pytest fixture, as the fixture does exactly the same contextmanager logic.